### PR TITLE
Update amiga1000.json

### DIFF
--- a/MachineList/commodore/amiga1000.json
+++ b/MachineList/commodore/amiga1000.json
@@ -7,7 +7,7 @@
       "type": "68000",
       "speed": "7.1MHz"
     },
-    "ram": 131072,
+    "ram": 262144,
     "release": {
       "year": 1985,
       "month": 7


### PR DESCRIPTION
Original Amiga 1000 came with 256 KB RAM. http://www.obsoletecomputermuseum.org/a1000/specs.shtml